### PR TITLE
优化 make:model 命令表名复数的小问题

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "source": "https://github.com/webman-php/console"
   },
   "require": {
-    "symfony/console": ">=5.0"
+    "symfony/console": ">=5.0",
+    "doctrine/inflector": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Util.php
+++ b/src/Util.php
@@ -1,6 +1,8 @@
 <?php
 namespace Webman\Console;
 
+use Doctrine\Inflector\InflectorFactory;
+
 class Util
 {
     public static function nameToNamespace($name)
@@ -14,10 +16,8 @@ class Util
 
     public static function classToName($class)
     {
-        $class = lcfirst($class);
-        return preg_replace_callback(['/([A-Z])/'], function ($matches) {
-            return '_' . strtolower($matches[1]);
-        }, $class);
+        $inflector = InflectorFactory::create()->build();
+        return $inflector->pluralize($inflector->tableize($class));
     }
 
     public static function nameToClass($class)


### PR DESCRIPTION
在创建model时，自动生成的字段注释在后续开发中可以很方便的查看。
但是因为表名复数化时，因为英文单词语法的原因，个别单词的复数不是添加 s 而是有变形，所以会导致有一些表明无法自动生成注释。

因为没有找到比较好的方法，就使用了一个第三方的类库做了单词复数的操作，不知道是否会增加复杂度，根据实际情况酌情审核合并吧。