### PR TITLE
Fix unix dirname error

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -24,10 +24,13 @@ class Command extends Application
             if ($file->getExtension() !== 'php') {
                 continue;
             }
+            // abc\def.php
             $relativePath = str_replace(str_replace('/', '\\', $path . '\\'), '', str_replace('/', '\\', $file->getRealPath()));
-            $realNamespace = trim($namspace . '\\' . trim(dirname($relativePath), '.'), '\\');
+            // app\command\abc
+            $realNamespace = trim($namspace . '\\' . trim(dirname(str_replace('\\', DIRECTORY_SEPARATOR, $relativePath)), '.'), '\\');
+            // app\command\doc\def
             $class_name = trim($realNamespace . '\\' . $file->getBasename('.php'), '\\');
-            if (!is_a($class_name, Commands::class, true)) {
+            if (!class_exists($class_name) || !is_a($class_name, Commands::class, true)) {
                 continue;
             }
             $this->add(new $class_name);


### PR DESCRIPTION
```php
dirname('abc\\def.php'); // windows: abc linux: .
```