### PR TITLE
fix phar pack error

### DIFF
--- a/src/Commands/PharPackCommand.php
+++ b/src/Commands/PharPackCommand.php
@@ -42,7 +42,7 @@ class PharPackCommand extends Command
             unlink($phar_file);
         }
 
-        $exclude_pattern = config('plugin.webman.console.app.exclude_pattern');
+        $exclude_pattern = config('plugin.webman.console.app.exclude_pattern','');
         $phar = new Phar($phar_file,0,'webman');
 
         $phar->startBuffering();


### PR DESCRIPTION
Phar::buildFromDirectory(): Passing null to parameter #2 ($pattern) of type string is deprecated