### PR TITLE
fix Fatal error: Uncaught ErrorException: Undefined array key "defaultName"

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -41,7 +41,7 @@ class Command extends Application
                 continue;
             }
             $properties = $reflection->getStaticProperties();
-            $name = $properties['defaultName'];
+            $name = $properties['defaultName'] ?? null;
             if (!$name) {
                 throw new RuntimeException("Command {$class_name} has no defaultName");
             }


### PR DESCRIPTION
## fix Fatal error: Uncaught ErrorException: Undefined array key "defaultName"

新版console移除了defaultName，存在类没有定义defaultName属性的可能，导致反射无法获取，导致数组未定义键的fatal error