### PR TITLE
load error reporting level from config

### DIFF
--- a/src/webman
+++ b/src/webman
@@ -18,6 +18,11 @@ if ($timezone = $appConfig['default_timezone'] ?? '') {
     date_default_timezone_set($timezone);
 }
 
+$errorReporting = $appConfig['error_reporting'];
+if (isset($errorReporting)) {
+    error_reporting($errorReporting);
+}
+
 if (!in_array($argv[1] ?? '', ['start', 'restart', 'stop', 'status', 'reload', 'connections'])) {
     require_once __DIR__ . '/support/bootstrap.php';
 } else {


### PR DESCRIPTION
執行 `webman` cli 時也讀取 error reporting 等級設定。

----

事情起因是這個 issue：https://github.com/webman-micro/migrations/issues/1

關於該問題比較細節的部分就不複製貼上到這邊，主要是爬梳問題的過程中，發現框架在啟動處理請求等動作，[皆有讀取 `config/app.php` 中 error_reporting level](https://github.com/walkor/webman-framework/blob/master/src/support/App.php#L54)，可是 `webman` 這個 CLI plugin 卻沒有，導致兩邊行為不一致，所以發出這個 PR 修正此問題。

如果有其他考量，認為不適合和應用程式共用該設定，我會希望是多新增一項設定，而非讓 plugin 行為和框架本身不一致。