### PR TITLE
feat: 检测加载 .env 配置文件

### DIFF
--- a/src/webman
+++ b/src/webman
@@ -5,6 +5,7 @@ use Webman\Config;
 use Webman\Console\Command;
 use Webman\Console\Util;
 use support\Container;
+use Dotenv\Dotenv;
 if (!Phar::running()) {
     chdir(__DIR__);
 }
@@ -13,6 +14,15 @@ require_once __DIR__ . '/vendor/autoload.php';
 if (!$appConfigFile = config_path('app.php')) {
     throw new RuntimeException('Config file not found: app.php');
 }
+
+if (class_exists(Dotenv::class) && file_exists(run_path('.env'))) {
+  if (method_exists(Dotenv::class, 'createUnsafeImmutable')) {
+    Dotenv::createUnsafeImmutable(run_path())->load();
+  } else {
+    Dotenv::createMutable(run_path())->load();
+  }
+}
+
 $appConfig = require $appConfigFile;
 if ($timezone = $appConfig['default_timezone'] ?? '') {
     date_default_timezone_set($timezone);


### PR DESCRIPTION
- 在应用启动时，检查是否存在 .env 文件和相关类，如果存在，使用 Dotenv 库加载环境变量
- 修复在 bin 打包后因使用 env 定义进程名而导致出现多出默认webman进程的情况