### PR TITLE
feat(MakeModelCommand): 添加跳过确认选项

### DIFF
--- a/src/Commands/MakeModelCommand.php
+++ b/src/Commands/MakeModelCommand.php
@@ -24,6 +24,7 @@ class MakeModelCommand extends Command
         $this->addArgument('name', InputArgument::REQUIRED, 'Model name');
         $this->addArgument('type', InputArgument::OPTIONAL, 'Type');
         $this->addOption('connection', 'c', InputOption::VALUE_OPTIONAL, 'Select database connection. ');
+        $this->addOption('yes', 'y', InputOption::VALUE_NONE, 'Skip confirmation');
     }
 
     /**
@@ -75,7 +76,7 @@ class MakeModelCommand extends Command
             $type = !$database && $thinkorm ? 'tp' : 'laravel';
         }
 
-        if (is_file($file)) {
+        if (is_file($file) && !$input->getOption('yes')) {
             $helper = $this->getHelper('question');
             $question = new ConfirmationQuestion("$file already exists. Do you want to override it? (yes/no)", false);
             if (!$helper->ask($input, $output, $question)) {


### PR DESCRIPTION
- 新增 --yes/-y 选项用于跳过文件覆盖确认
- 当存在同名文件时，可通过 --yes 选项直接覆盖
- 保留原有交互式确认逻辑作为默认行为
- 当使用自动化脚本执行相关命令时可以跳过确认步骤